### PR TITLE
Ikke lever liste med utvidet for år etter 2023

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/skatteetaten/rest/SkatteetatenController.kt
+++ b/src/main/kotlin/no/nav/familie/ba/skatteetaten/rest/SkatteetatenController.kt
@@ -41,7 +41,11 @@ class SkatteetatenController(
         aar: Int,
     ): ResponseEntity<SkatteetatenPersonerResponse> {
         logger.info("Henter skatteetaten-personer for år=$aar")
-        return ResponseEntity(service.finnPersonerMedUtvidetBarnetrygd(aar.toString()), HttpStatus.OK)
+        return if (aar > SISTE_ÅR_MED_SÆRFRADRAG_UTVIDET_BARNETRYGD) {
+            ResponseEntity(SkatteetatenPersonerResponse(), HttpStatus.OK)
+        } else {
+            ResponseEntity(service.finnPersonerMedUtvidetBarnetrygd(aar.toString()), HttpStatus.OK)
+        }
     }
 
     @PostMapping(
@@ -74,5 +78,6 @@ class SkatteetatenController(
 
     companion object {
         const val MAX_ANTALL_I_PERIODER = 10000
+        const val SISTE_ÅR_MED_SÆRFRADRAG_UTVIDET_BARNETRYGD = 2023
     }
 }

--- a/src/test/kotlin/no/nav/familie/ba/skatteetaten/rest/SkatteetatenControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/skatteetaten/rest/SkatteetatenControllerTest.kt
@@ -8,6 +8,15 @@ import org.junit.jupiter.api.Test
 
 class SkatteetatenControllerTest {
     @Test
+    fun `personer for år etter 2023 skal returnere tom liste`() {
+        val skatteetatenController = SkatteetatenController(mockk())
+
+        val response = skatteetatenController.finnPersonerMedUtvidetBarnetrygd(2024)
+
+        assertEquals(response.body?.brukere?.size, 0)
+    }
+
+    @Test
     fun `erSkatteetatenPeriodeRequestGyldig skal fange opp ugyldig input`() {
         val skatteetatenController = SkatteetatenController(mockk())
 


### PR DESCRIPTION
Særfradraget avsluttet i 1 mars 2023. Skatt har ingen behov for å hente denne dataen for 2024.